### PR TITLE
Relax containers and hashable bounds

### DIFF
--- a/matchable.cabal
+++ b/matchable.cabal
@@ -26,9 +26,9 @@ library
                       , Data.Bimatchable
                       , Data.Functor.Classes.Orphans
   build-depends:        base                 >=4.10      && <5,
-                        containers           >=0.5.10.2  && <0.7,
+                        containers           >=0.5.10.2  && <0.8,
                         tagged               >=0.8       && <0.9,
-                        hashable             >=1.0.1.1   && <1.5,
+                        hashable             >=1.0.1.1   && <1.6,
                         unordered-containers >=0.2.6     && <0.3,
                         vector               >=0.10.9.0  && <0.14,
                         generically          >=0.1


### PR DESCRIPTION
I've tested this with the new version of hashable and the test suite passes.

Could you please make a Hackage revision when you get a chance?

See: https://github.com/commercialhaskell/stackage/issues/7476